### PR TITLE
Main

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Python Library For interacting with EO Home EV Chargers.
 
 This has only been tested with a EO Mini Pro 2.
 
+Forked by MuddyRock from @bfayers original work.
+I am using this to teach myself Python - constructive feedback on my coding and just how bad it is, is welcome, but please be gentle!
+
 Example usage:
 
 ```python
@@ -19,4 +22,14 @@ print(sessions) #Print list of sessions from all time from first device on accou
 
 devices[0].disable() #Disable/lock the charger
 devices[0].enable() #Enable/unlock the charger
+
+currentChargeOpt = devices[0].get_chargeOpts() #get charger current settings
+print(currentChargeOpt.__dict__) #show charger current settings
+
+Note that among other things, get_chargeOpts returns a cpid which is needed to amend options (see set_chargeOpts)
+
+newChargeOpts = eocharging.Device.chargeOpts(cpid=currentChargeOpt.cpid,opMode=newOpMode) #Construct new charger options - for full list, see those returned from get_chargeOpts()
+devices[0].set_chargeOpts(newChargeOpts) #Set charger options. cpid is mandatory, plus at least one option to change.
+currentChargeOpt = devices[0].get_chargeOpts() #Check new option was applied successfully
+
 ```

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Python Library For interacting with EO Home EV Chargers.
 
 This has only been tested with a EO Mini Pro 2.
 
-Forked by MuddyRock from @bfayers original work.
-I am using this to teach myself Python - constructive feedback on my coding and just how bad it is, is welcome, but please be gentle!
 
 Example usage:
 

--- a/eocharging/Device.py
+++ b/eocharging/Device.py
@@ -1,11 +1,50 @@
-import requests
-from datetime import datetime, timedelta
 import time
-from requests.api import head
+from datetime import datetime, timedelta
 
+import requests
+from requests.api import head
 from requests.models import Response
+
+from eocharging.ChargingData import LiveSession, Session
 from eocharging.Helpers import eo_base_url as base_url
-from eocharging.ChargingData import Session, LiveSession
+
+
+class chargeOpts:
+    def __init__(self,cpid=None, scheduleWDay=None,scheduleWEnd=None,tariffWDay=None,tariffWEnd=None,appSchedWDay=None,appSchedWEnd=None,solarMin=None,timeMode=None,solarMode=None,opMode=None,pricePeak=None,priceOffPeak=None,tnid=None,tariffZone=None):
+        if cpid is None:
+            raise Exception("No cpid provided")
+        if scheduleWDay is None and\
+           scheduleWEnd is None and\
+           tariffWDay is None and\
+           tariffWEnd is None and\
+           appSchedWDay is None and\
+           appSchedWEnd is None and\
+           solarMin is None and\
+           timeMode is None and\
+           solarMode is None and\
+           opMode is None and\
+           pricePeak is None and\
+           priceOffPeak is None and\
+           tnid is None and\
+           tariffZone is None:
+           raise Exception("Must provide at least one of scheduleWDay, scheduleWEnd, tariffWDay, tariffWEnd, appSchedWDay, appSchedWEnd, solarMin, timeMode, solarMode, opMode, pricePeak, priceOffPeak, tnid, or tariffZone")
+                
+        self.cpid = cpid
+        self.scheduleWDay = scheduleWDay
+        self.scheduleWEnd = scheduleWEnd
+        self.tariffWDay = tariffWDay
+        self.tariffWEnd = tariffWEnd
+        self.appSchedWDay = appSchedWDay
+        self.appSchedWEnd = appSchedWEnd
+        self.solarMin = solarMin
+        self.timeMode = timeMode
+        self.solarMode = solarMode
+        self.opMode = opMode
+        self.pricePeak = pricePeak
+        self.priceOffPeak = priceOffPeak
+        self.tnid = tnid
+        self.tariffZone = tariffZone
+
 
 
 class Device:
@@ -13,6 +52,7 @@ class Device:
         self,
         device_address=None,
         access_token=None,
+        is_disabled=None,
         hub_address=None,
         charger_model=None,
         hub_model=None,
@@ -35,11 +75,85 @@ class Device:
         self.device_address = device_address
         self.headers = {"Authorization": "Bearer " + access_token}
         self.access_token = access_token
+        self.hub_serial = hub_serial
+        self.is_disabled = is_disabled
         # Commented out for now as these aren't strictly necesarry
         # self.hub_address = hub_address
         # self.charger_model = charger_model
         # self.hub_model = hub_model
-        # self.hub_serial = hub_serial
+
+    def get_chargeOpts(self):
+        """Retrieves full list of charger options - these can also be set using set_chargeOpts"""
+        url = base_url + "api/user"
+        response = requests.get(url, headers=self.headers)
+        if response.status_code != 200:
+            raise Exception("Response was not OK")
+        else:
+            data = response.json()
+            data = data['chargeOpts']
+            chargeOpt = chargeOpts(
+                cpid=data['cpid'],
+                scheduleWDay=data['scheduleWDay'],
+                scheduleWEnd=data['scheduleWEnd'],
+                tariffWDay=data['tariffWDay'],
+                tariffWEnd=data['tariffWEnd'],
+                appSchedWDay=data['appSchedWDay'],
+                appSchedWEnd=data['appSchedWEnd'],
+                solarMin=data['solarMin'],
+                timeMode=data['timeMode'],
+                solarMode=data['solarMode'],
+                opMode=data['opMode'],
+                pricePeak=data['pricePeak'],
+                priceOffPeak=data['priceOffPeak'],
+                tnid=data['tnid'],
+                tariffZone=data['tariffZone']
+            )
+            return chargeOpt
+
+    def set_chargeOpts(self, opts: chargeOpts=None):
+
+        if opts is None:
+            raise Exception("Must provide options to set")
+
+        url = base_url + "api/user/updateChargeOpts"
+
+        payload = {}
+        payload["cpid"] = opts.cpid
+        if opts.scheduleWDay is not None:
+            payload["scheduleWDay"] = opts.scheduleWDay
+        if opts.scheduleWEnd is not None:
+            payload['scheduleWEnd'] = opts.scheduleWEnd
+        if opts.tariffWDay is not None:
+            payload['tariffWDay'] = opts.tariffWDay
+        if opts.tariffWEnd is not None:
+            payload['tariffWEnd'] = opts.tariffWEnd
+        if opts.appSchedWDay is not None:
+            payload['appSchedWDay'] = opts.appSchedWDay
+        if opts.appSchedWEnd is not None:
+            payload['appSchedWEnd'] = opts.appSchedWEnd
+        if opts.solarMin is not None:
+            payload['solarMin'] = opts.solarMin
+        if opts.timeMode is not None:
+            payload['timeMode'] = opts.timeMode
+        if opts.solarMode is not None:
+            payload['solarMode'] = opts.solarMode
+        if opts.opMode is not None:
+            payload['opMode'] = opts.opMode
+        if opts.pricePeak is not None:
+            payload['pricePeak'] = opts.pricePeak
+        if opts.priceOffPeak is not None:
+            payload['priceOffPeak'] = opts.priceOffPeak
+        if opts.tnid is not None:
+            payload['tnid'] = opts.tnid
+        if opts.tariffZone is not None:
+            payload['tariffZone'] = opts.tariffZone           
+
+        response = requests.post(url, headers=self.headers, data=payload)
+        if response.status_code != 200:
+            raise Exception("Response was not OK")
+        else:
+            return self.get_chargeOpts()
+
 
     def enable(self):
         """Used for enabling a disabled charger, also known as unlocking"""

--- a/eocharging/Manager.py
+++ b/eocharging/Manager.py
@@ -37,6 +37,6 @@ class Manager:
         devices = []
         for device in data:
             devices.append(
-                Device(device_address=device["address"], access_token=self.access_token)
+                Device(device_address=device["address"], is_disabled=device["isDisabled"], hub_serial=device["hubSerial"], access_token=self.access_token)
             )
         return devices

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name="pyEOCharging",
     packages=find_packages(include=["eocharging"]),
-    version="0.0.5",
+    version="0.0.6",
     description="EO Smart Charger Library",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Add ability to get/set charger options.
For example, setting off peak mode, solar mode and scheduled mode all to off (0), while the charger is enabled will effectively turn  the charger on and send power to the car.

For full available options, see the class definition, and the reply from get_chargeOpts()
